### PR TITLE
fix: Cloudimage baseURL の指定を更新

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -67,10 +67,7 @@ export default defineNuxtConfig({
   image: {
     cloudimage: {
       token: process.env.NUXT_PUBLIC_CLOUDIMAGE_TOKEN,
-      baseURL:
-        process.env.NODE_ENV?.toLowerCase() === 'production'
-          ? process.env.CF_PAGES_URL
-          : process.env.NUXT_PUBLIC_BASE_URL,
+      baseURL: process.env.NUXT_PUBLIC_BASE_URL || process.env.CF_PAGES_URL,
     },
   },
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善点**
	- `cloudimage`設定の`baseURL`ロジックを簡素化しました。環境変数`NUXT_PUBLIC_BASE_URL`と`CF_PAGES_URL`を使用する単一の表現に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->